### PR TITLE
Incorrect use of absolute path

### DIFF
--- a/src/traits/attachments.php
+++ b/src/traits/attachments.php
@@ -45,7 +45,7 @@ trait attachments
 		$this->debug( 'Copy attachment: Checking filetype.' );
 		$wp_filetype = wp_check_filetype( $target, null );
 		$attachment = [
-			'guid' => $upload_dir[ 'url' ] . '/' . $target,
+			'guid' => $upload_dir[ 'url' ] . '/' . basename($target),
 			'menu_order' => $attachment_data->post->menu_order,
 			'post_author' => $attachment_data->post->post_author,
 			'post_excerpt' => $attachment_data->post->post_excerpt,


### PR DESCRIPTION
`$target` holds an absolute path, so `$upload_dir[ 'url' ] . '/' .$target` is an incorrect path.